### PR TITLE
Change anchor for link to image credit.

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ layout: default
     </p>
     <a class="btn btn-primary btn-lg" href="Flux.jl" role="button">Try It Out</a>
   </div>
-  <a href="http://blog.otoro.net/2016/03/25/generating-abstract-patterns-with-tensorflow/"><div class="info bottom right white"> Blog Post</div></a>
+  <a href="http://blog.otoro.net/2016/03/25/generating-abstract-patterns-with-tensorflow/"><div class="info bottom right white"> Image Credit</div></a>
 </div>
 
 <!-- Main Content -->


### PR DESCRIPTION
The current anchor text of "Blog Post" makes it seem like that is a blog post describing Flux.