### PR TITLE
TensorBoard project: add mentor and reword project

### DIFF
--- a/gsoc.md
+++ b/gsoc.md
@@ -53,14 +53,14 @@ Mentors: [Dhairya Gandhi](https://github.com/dhairyagandhi96/), [Elliot Saba](ht
 
 [TensorBoard](https://www.tensorflow.org/guide/summaries_and_tensorboard) is a powerful toolkit for visualising ML training, especially useful when training on a remote server. This project would involve setting up a pure-Julia TensorBoard client that hooks into Julia's logging system to log Julia programs, including ML training. The project should demonstrate Flux integration and visualising training of a Flux model. But more broadly it should be able to work with any julia project that uses the logging standard library, from JuMP constrained optimisation solvers to iterative matrix factorization methods.
 
-Previous work include [TensorBoard.jl](https://github.com/zenna/Tensorboard.jl) and [UniversalTensorBoard.jl](https://github.com/oxinabox/UniversalTensorBoard.jl).
+A proof of concept can be found at [TensorBoardLogger.jl](https://github.com/PhilipVinc/TensorBoardLogger.jl), and could be used as a starting point for this project. A good source of inspiration might be Python's [TensorboardX](https://github.com/lanpa/tensorboardX). Previous work in Julia also include [UniversalTensorBoard.jl](https://github.com/oxinabox/UniversalTensorBoard.jl). 
 
 For the application it would be useful to build familiarity with:
 - The Julia logging system
 - Protobuf and ProtoBuf.jl
 - TensorBoard as used in e.g. python
 
-Mentors: [Lyndon White](https://github.com/oxinabox)
+Mentors: [Filippo Vicentini](https://github.com/PhilipVinc), [Lyndon White](https://github.com/oxinabox)
 
 ### Multi-GPU training
 


### PR DESCRIPTION
As discussed on Slack with @oxinabox 
Add myself as a mentor to the TensorBoard project
Mention TensorBoardLogger.jl as a possible starting implementation
Remove `TensorBoard.jl` and just mention TensorboardX.