### PR TITLE
Added community team to website

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,6 +246,13 @@ title: Elegant ML
     <div class="row">
 
       <div class="col-md feature">
+        <h5>Community team</h5>
+        <p>
+          Join the <a href="https://github.com/FluxML/ML-Coordination-Tracker">group of community maintainers</a> supporting the FluxML ecosystem.
+        </p>
+      </div>
+
+      <div class="col-md feature">
         <h5>Discourse forum</h5>
         <p>
           <a href="https://discourse.julialang.org/c/domain/ML/24">Machine Learning in Julia</a> community.


### PR DESCRIPTION
Adds a link under the "Community" header to the community team repo.