### PR TITLE
docs: Changes to the Getting Started document

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -117,11 +117,11 @@ opt = Descent(0.01)
 
 ### Step 6: Train your model
 
-Training a model is the process of computing the gradients with respect to the parameters for each data point in the data. At every step, the optimiser updates all of the parameters until it finds a good value for them. You can write this process as a for-loop. We iterate over the examples in `x_train` and `y_train` and update the model for each example.
+Training a model is the process of computing the gradients with respect to the parameters for each input in the data. At every step, the optimiser updates all of the parameters until it finds a good value for them. This process can be written as a loop: we iterate over the examples in `x_train` and `y_train` and update the model for each example.
 
-Note that we set `ps = params([W, b])` to indicate that we want all derivatives of `W` and `b`. This is a convenience function that Flux provides so that we don't have to explicitly list every gradient we want. Check out the section on [Taking Gradients](https://fluxml.ai/Flux.jl/stable/models/basics/#Taking-Gradients) if you want to learn more about how this works.
+To indicate that we want all derivatives of `W_learned` and `b_learned`, we write `ps = params([W, b])`. This is a convenience function that Flux provides so that we don't have to explicitly list every gradient we want. Check out the section on [Taking Gradients](https://fluxml.ai/Flux.jl/stable/models/basics/#Taking-Gradients) if you want to learn more about how this works.
 
-You can execute the training process of your model as follows:
+We can now execute the training procedure for our model:
 
 ```julia
 train_data = zip(x_train, y_train)
@@ -138,11 +138,11 @@ end
 <br>
 
 
->**Note:** With this pattern, it is trivial to add more complex learning routines that make use of control flow, distributed compute, scheduling optimisation etc. Note that the pattern above is a simple julia *for loop* but it could also be replaced with a *while loop*.
+>**Note:** With this pattern, it is easy to add more complex learning routines that make use of control flow, distributed compute, scheduling optimisation, etc. Note that the pattern above is a simple julia *for loop* but it could also be replaced with a *while loop*.
 
 <br>
 
-Flux lets you do the same process with the [Flux.train!](https://fluxml.ai/Flux.jl/stable/training/training/#Training-1) function. `train!` executes a single training step, and you can also put it inside a for-loop to execute more training steps. For more information on training a model in Flux, see [Training](https://fluxml.ai/Flux.jl/stable/training/training/#Training-1). 
+Flux lets you do the same process with the [Flux.train!](https://fluxml.ai/Flux.jl/stable/training/training/#Training-1) function. `train!` executes a single training step, and you can also put it inside a for-loop to execute multiple training steps. For more information on training a model in Flux, see [Training](https://fluxml.ai/Flux.jl/stable/training/training/#Training-1). 
 
 ```julia
 for d in train_data
@@ -163,7 +163,7 @@ print("The largest element-wise difference between W_learned and W_actual is ")
 println(maximum(abs.(W_learned - W_actual))
 ```
 
-Because the data points and initialization are random, your results may vary slightly, but in most cases, the largest difference between the elements of learned and actual `W` matrix is no more than 4%.
+Because the data and initialization are random, your results may vary slightly, but in most cases, the largest difference between the elements of learned and actual `W` matrix is no more than 4%.
 
 ### Step 8: Run the script
 
@@ -239,7 +239,7 @@ println(maximum(abs.(b_learned - b_actual)))
 
 ## What's next
 
-Congratulations! You have created your first model and ran a training step using Flux. Now, you can continue exploring Flux's capabilities:
+Congratulations! You have created written and trained a model using Flux. Now, you can continue exploring Flux's capabilities:
 
 * [60-minute blitz tutorial](tutorials/2020/09/15/deep-learning-flux.html) is a quick intro to Flux loosely based on [PyTorch's tutorial](https://pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html).
 * [Flux Model Zoo](https://github.com/FluxML/model-zoo) contains various demonstrations of Flux. 

--- a/getting_started.md
+++ b/getting_started.md
@@ -138,17 +138,19 @@ end
 <br>
 
 
->**Note:** With this pattern, it is easy to add more complex learning routines that make use of control flow, distributed compute, scheduling optimisation, etc. Note that the pattern above is a simple julia *for loop* but it could also be replaced with a *while loop*.
+>**Note:** With this pattern, it is easy to add more complex learning routines that make use of control flow, distributed compute, scheduling optimisations, etc. Note that the pattern above is a simple julia *for loop* but it could also be replaced with a *while loop*.
 
 <br>
 
-Flux lets you do the same process with the [Flux.train!](https://fluxml.ai/Flux.jl/stable/training/training/#Training-1) function. `train!` executes a single training step, and you can also put it inside a for-loop to execute multiple training steps. For more information on training a model in Flux, see [Training](https://fluxml.ai/Flux.jl/stable/training/training/#Training-1). 
+While writing your own loop is powerful, sometimes you just want to do the simple thing without writing too much code. Flux lets you do this with the [Flux.train!](https://fluxml.ai/Flux.jl/stable/training/training/#Training-1) function, which computes a gradient and updates the model for *every* example in a set (running what is often referred to as a *training epoch*). In our case, we could have replaced the entire loop with the following statement:
 
 ```julia
-for d in train_data
-  Flux.train!(loss, params(model), d, opt)
-end
+Flux.train!(loss, params(W_learned, b_learned), train_data, opt)
 ```
+
+<br>
+
+For more ways to train a model in Flux, see [Training](https://fluxml.ai/Flux.jl/stable/training/training/#Training-1).
 
 <br>
 
@@ -214,20 +216,18 @@ for d in train_data
   Flux.Optimise.update!(opt, ps, gs)
 end
 
-# We could also have used this loop to train the model instead.
-#=
-for d in train_data
-  Flux.train!(loss, params(model), data, opt)
-end
-=#
+# We could have replaced the above for-loop with this single call to train!, 
+# which handles the looping, gradient computations, and updates for us.
+# Flux.train!(loss, params(model), data, opt)
 
 # Print some information about how well the training process worked.
-println("The value of W_learned is:")
+print("The value of W_learned is: ")
 display(W_learned)
 println()
 print("The largest element-wise difference between W_learned and W_actual is ")
 println(maximum(abs.(W_learned - W_actual)))
-println("The value of b_learned is:")
+println()
+print("The value of b_learned is: ")
 display(b_learned)
 println()
 print("The largest element-wise difference between b_learned and b_actual is ")

--- a/getting_started.md
+++ b/getting_started.md
@@ -91,7 +91,7 @@ b_learned = rand(2)
 
 ### Step 4: Define a loss function
 
-A loss function evaluates a machine learning model's performance. In other words, it measures how far the model is from its target prediction. Flux lets you to define your own custom loss function, or you can use one of the [Loss Functions](https://fluxml.ai/Flux.jl/stable/training/training/#Loss-Functions-1) that Flux provides. 
+A loss function evaluates a machine learning model's performance. In other words, it measures how far the model is from its target prediction. Flux lets you define your own custom loss function, or you can use one of the [Loss Functions](https://fluxml.ai/Flux.jl/stable/training/training/#Loss-Functions-1) that Flux provides. 
 
 For this example, we'll define a loss function that measures the squared distance from the predicted output to the actual output:
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -59,7 +59,7 @@ First, we'll write a function that generates our "true" data. We'll use to use F
 W_truth = [1 2 3 4 5;
             5 4 3 2 1]
 b_truth = [-1.0; -2.0]
-ground_truth(x) = W_truth * x .+ b_truth
+ground_truth(x) = W_truth*x .+ b_truth
 ```
 <br>
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -29,7 +29,7 @@ julia> using Pkg; Pkg.add("Flux")
 
 <br>
 
-Flux provides GPU support. For more information on obtaining GPU support, see [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl) and [Flux documentation on GPU suppoort](https://fluxml.ai/Flux.jl/stable/gpu/).
+Flux provides GPU support. For more information on obtaining GPU support, see [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl) and [Flux documentation on GPU support](https://fluxml.ai/Flux.jl/stable/gpu/).
 
 <br>
 
@@ -91,7 +91,7 @@ b_learned = rand(2)
 
 ### Step 4: Define a loss function
 
-A loss function evaluates a machine learning model's performance. In other words, it measures how far the model is from its target prediction. Flux lets you gdefine your own custom loss function, or you can use one of the [Loss Functions](https://fluxml.ai/Flux.jl/stable/training/training/#Loss-Functions-1) that Flux provides. 
+A loss function evaluates a machine learning model's performance. In other words, it measures how far the model is from its target prediction. Flux lets you define your own custom loss function, or you can use one of the [Loss Functions](https://fluxml.ai/Flux.jl/stable/training/training/#Loss-Functions-1) that Flux provides. 
 
 For this example, we'll define a loss function that measures the squared distance from the predicted output to the actual output:
 
@@ -138,7 +138,7 @@ end
 <br>
 
 
->**Note:** With this pattern, it is easy to add more complex learning routines that make use of control flow, distributed compute, scheduling optimisations, etc. Note that the pattern above is a simple julia *for loop* but it could also be replaced with a *while loop*.
+>**Note:** With this pattern, it is easy to add more complex learning routines that make use of control flow, distributed compute, scheduling optimisations, etc. Note that the pattern above is a simple Julia *for loop* but it could also be replaced with a *while loop*.
 
 <br>
 
@@ -246,4 +246,4 @@ Congratulations! You have created written and trained a model using Flux. Now, y
 * [JuliaAcademy](https://juliaacademy.com/) offers introductory courses to Julia and Flux.
 * [Flux's official documentation](https://fluxml.ai/Flux.jl/stable/).
 
-As you countinue to progress through your Flux and Julia journey, please feel free to share it on [Twitter and tag us](https://twitter.com/FluxML), we would love to see what awesome things the #FluxML community is up to.
+As you continue to progress through your Flux and Julia journey, please feel free to share it on [Twitter and tag us](https://twitter.com/FluxML), we would love to see what awesome things the #FluxML community is up to.

--- a/getting_started.md
+++ b/getting_started.md
@@ -91,7 +91,7 @@ b_learned = rand(2)
 
 ### Step 4: Define a loss function
 
-A loss function evaluates a machine learning model's performance. In other words, it measures how far the model is from its target prediction. Flux lets you define your own custom loss function, or you can use one of the [Loss Functions](https://fluxml.ai/Flux.jl/stable/training/training/#Loss-Functions-1) that Flux provides. 
+A loss function evaluates a machine learning model's performance. In other words, it measures how far the model is from its target prediction. Flux lets you gdefine your own custom loss function, or you can use one of the [Loss Functions](https://fluxml.ai/Flux.jl/stable/training/training/#Loss-Functions-1) that Flux provides. 
 
 For this example, we'll define a loss function that measures the squared distance from the predicted output to the actual output:
 
@@ -189,7 +189,7 @@ training_model(x) = W_learned * x + b_learned
 
 # Set random initial weights for the parameters of the model
 W_learned = rand(2,5)
-b_learned = zeros(2)
+b_learned = rand(2)
 
 # Define a simple squared-distance loss function
 function loss(x, y)
@@ -218,7 +218,7 @@ end
 
 # We could have replaced the above for-loop with this single call to train!, 
 # which handles the looping, gradient computations, and updates for us.
-# Flux.train!(loss, params(model), data, opt)
+# Flux.train!(loss, params(W_learned, b_learned), train_data, opt)
 
 # Print some information about how well the training process worked.
 print("The value of W_learned is: ")

--- a/getting_started.md
+++ b/getting_started.md
@@ -142,7 +142,7 @@ end
 
 <br>
 
-While writing your own loop is powerful, sometimes you just want to do the simple thing without writing too much code. Flux lets you do this with the [Flux.train!](https://fluxml.ai/Flux.jl/stable/training/training/#Training-1) function, which computes a gradient and updates the model for *every* example in a set (running what is often referred to as a *training epoch*). In our case, we could have replaced the entire loop with the following statement:
+While writing your own loop is powerful, sometimes you just want to do the simple thing without writing too much code. Flux lets you do this with [Flux.train!](https://fluxml.ai/Flux.jl/stable/training/training/#Training-1), which runs one training epoch over a dataset. `Flux.train!` computes gradients and updates model parameters for every sample or batch of samples. In our case, we could have replaced the above loop with the following statement:
 
 ```julia
 Flux.train!(loss, params(W_learned, b_learned), train_data, opt)

--- a/getting_started.md
+++ b/getting_started.md
@@ -181,30 +181,28 @@ using Flux
 # only examples of ground_truth()
 W_truth = [1 2 3 4 5;
             5 4 3 2 1]
-b_truth = [- 1.0; -2.0]
-ground_truth(x) = W_truth * x .+ b_truth
+b_truth = [-1.0; -2.0]
+ground_truth(x) = W_truth*x .+ b_truth
 
 # Generate the ground truth training data as vectors-of-vectors
 x_train = [ 5 .* rand(5) for _ in 1:10_000 ]
 y_train = [ ground_truth(x) + 0.2 .* randn(2) for x in x_train ]
 
 # Define and initialize the model we want to train
-model(x) = W*x + b
+model(x) = W*x .+ b
 W = rand(2, 5)
 b = rand(2)
 
-# Define the loss function and optimizer
+# Define pieces we need to train: loss function, optimiser, examples, and params
 function loss(x, y)
   ŷ = model(x)
-  sum((y - ŷ).^2)
+  sum((y .- ŷ).^2)
 end
-
 opt = Descent(0.01)
-
-# Execute a training epoch
 train_data = zip(x_train, y_train)
 ps = params(W, b)
 
+# Execute a training epoch
 for (x,y) in train_data
   gs = Flux.gradient(ps) do
     loss(x,y)
@@ -215,7 +213,7 @@ end
 # An alternate way to execute a training epoch
 # Flux.train!(loss, params(W, b), train_data, opt)
 
-# Print out how well we did.
+# Print out how well we did
 @show W
 @show maximum(abs, W .- W_truth)
 ```

--- a/getting_started.md
+++ b/getting_started.md
@@ -119,7 +119,7 @@ opt = Descent(0.01)
 
 Training a model is the process of computing the gradients with respect to the parameters for each input in the data. At every step, the optimiser updates all of the parameters until it finds a good value for them. This process can be written as a loop: we iterate over the examples in `x_train` and `y_train` and update the model for each example.
 
-To indicate that we want all derivatives of `W_learned` and `b_learned`, we write `ps = params([W, b])`. This is a convenience function that Flux provides so that we don't have to explicitly list every gradient we want. Check out the section on [Taking Gradients](https://fluxml.ai/Flux.jl/stable/models/basics/#Taking-Gradients) if you want to learn more about how this works.
+To indicate that we want all derivatives of `W_learned` and `b_learned`, we write `ps = params(W_learned, b_learned)`. This is a convenience function that Flux provides so that we don't have to explicitly list every gradient we want. Check out the section on [Taking Gradients](https://fluxml.ai/Flux.jl/stable/models/basics/#Taking-Gradients) if you want to learn more about how this works.
 
 We can now execute the training procedure for our model:
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -204,7 +204,7 @@ ps = params(W, b)
 
 # Execute a training epoch
 for (x,y) in train_data
-  gs = Flux.gradient(ps) do
+  gs = gradient(ps) do
     loss(x,y)
   end
   Flux.Optimise.update!(opt, ps, gs)

--- a/getting_started.md
+++ b/getting_started.md
@@ -58,7 +58,7 @@ First, we'll write a function that generates our "true" data. We'll use to use F
 ```julia
 W_truth = [1 2 3 4 5;
             5 4 3 2 1]
-b_truth = [- 1.0; -2.0]
+b_truth = [-1.0; -2.0]
 ground_truth(x) = W_truth * x .+ b_truth
 ```
 <br>

--- a/getting_started.md
+++ b/getting_started.md
@@ -82,7 +82,7 @@ machine learning problems:
 Next, we define the model we want to use to learn the data. We'll use the same form that we used for our training data:
 
 ```julia
-model(x) = W*x + b
+model(x) = W*x .+ b
 ```
 <br>
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -223,7 +223,7 @@ end
 
 ## What's next
 
-Congratulations! You have created written and trained a model using Flux. Now, you can continue exploring Flux's capabilities:
+Congratulations! You have created and trained a model using Flux. Now, you can continue exploring Flux's capabilities:
 
 * [60-minute blitz tutorial](tutorials/2020/09/15/deep-learning-flux.html) is a quick intro to Flux loosely based on [PyTorch's tutorial](https://pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html).
 * [Flux Model Zoo](https://github.com/FluxML/model-zoo) contains various demonstrations of Flux. 

--- a/getting_started.md
+++ b/getting_started.md
@@ -103,7 +103,7 @@ For this example, we'll define a loss function that measures the squared distanc
 ```julia
 function loss(x, y)
   ŷ = model(x)
-  sum((y - ŷ).^2)
+  sum((y .- ŷ).^2)
 end
 ```
 


### PR DESCRIPTION
This PR updates the "Getting Started" document with a more fleshed-out tutorial. Instead of running a single training step, it creates a model, generates noisy examples, and then attempts to learn the original model via examples. This shows new users what they have done, and how they can use the result of the training process.

### Potential Issues

According to BenchmarkTools, the old tutorial took a few milliseconds to run and consumed 18.5 KiB of memory, while the new one takes about 100ms to run and consumes 71.06 MiB of memory.

BenchmarkTools excludes compilation time, and in practice when I ran the two from the command line, the runtime appeared to be overwhelmingly dominated by the compilation time (approximately 20 seconds to complete each one), but the memory aspect may be of concern, depending on where users are expected to try this tutorial. I don't expect that this is an issue, since I couldn't even compile Flux on a VPS with 1GB RAM due to memory limits, but I don't know how this library is used. If 71MB of memory is a concern, I can attempt to cut down on the size of the training set at the cost of worse accuracy.

Also, in spite of the fact that I've written a SGD implementation or two, I'm actually not terribly familiar with the field of ML and am not particularly fluent with how things are usually talked about/described. If anyone would like wording or vocabulary changes to make things more idiomatic, I'd be happy to change those.