### PR TITLE
Update 2020-10-18-transfer-learning.md to re-train the whole model 

### DIFF
--- a/tutorials/_posts/2020-10-18-transfer-learning.md
+++ b/tutorials/_posts/2020-10-18-transfer-learning.md
@@ -78,8 +78,9 @@ loss(x,y) = Flux.Losses.logitcrossentropy(model(x), y)
 Now to train. As discussed earlier, we don’t need to pass all the parameters to our training loop. Only the ones we need to fine-tune. Note that we could have picked and chosen the layers we want to train individually as well, but this is sufficient for our use as of now.
 
 ```julia
-ps = Flux.params(model[2:end])  # ignore the already trained layers of the ResNet
+ps = Flux.params(model)
 ```
+Normally, you would only re-train the dense layers via `model[2:end]` but in this case, the pre-trained models from Metalhead.jl are not currently available. This will change in the future once the pre-trained models are once again available.
 <br>
 
 And now, let's train!

--- a/tutorials/_posts/2020-10-18-transfer-learning.md
+++ b/tutorials/_posts/2020-10-18-transfer-learning.md
@@ -80,7 +80,7 @@ Now to train. As discussed earlier, we don’t need to pass all the parameters t
 ```julia
 ps = Flux.params(model)
 ```
-Normally, you would only re-train the dense layers via `model[2:end]` but in this case, the pre-trained models from Metalhead.jl are not currently available. This will change in the future once the pre-trained models are once again available.
+**Note**: Normally, you would only re-train the dense layers via `model[2:end]` but in this case, the pre-trained models from Metalhead.jl are not currently available. This will change in the future once the pre-trained models are once again available.
 <br>
 
 And now, let's train!


### PR DESCRIPTION
Right now, the pre-trained models aren't available so the existing tutorial produces weird results since we only train the last two layers and the rest remain untrained. Per: https://stackoverflow.com/questions/70072282/flux-jl-model-always-outputs-1-0-after-adding-sigmoid-activation-function/70072665?noredirect=1#comment124001440_70072665