### PR TITLE
Minor error with 60 minute blitz tutorial

### DIFF
--- a/tutorials/_posts/2020-09-15-deep-learning-flux.md
+++ b/tutorials/_posts/2020-09-15-deep-learning-flux.md
@@ -385,7 +385,7 @@ Okay, first step. Let us perform the exact same preprocessing on this set, as we
 test_x, test_y = CIFAR10.testdata(Float32)
 test_labels = onehotbatch(test_y, 0:9)
 
-test = gpu.([(test_x[:,:,:,i], labels[:,i]) for i in partition(1:10000, 1000)])
+test = gpu.([(test_x[:,:,:,i], test_labels[:,i]) for i in partition(1:10000, 1000)])
 ```
 
 Next, display an image from the test set.


### PR DESCRIPTION
There was a minor error where the training labels were applied to the test data, which naturally gave random accuracy results later on.