### PR TITLE
Fix typo in dataloader constructor (Tutorial Blog Post)

### DIFF
--- a/tutorials/_posts/2021-01-21-data-loader.md
+++ b/tutorials/_posts/2021-01-21-data-loader.md
@@ -65,7 +65,7 @@ train_y, test_y = onehotbatch(train_y, 0:9), onehotbatch(test_y, 0:9)
 Now, we load the train images and their labels onto a DataLoader object:
  
 ```julia
-data_loader = DataLoader(train_x, train_y, batchsize=128, shuffle=true)
+data_loader = DataLoader((train_x, train_y); batchsize=128, shuffle=true)
 ```
 <br>
  


### PR DESCRIPTION
The example usage of dataloader does not match the API (maybe its outdated). This commit is to fix the example.