### PR TITLE
Fix broken link in MLP blog

### DIFF
--- a/tutorials/_posts/2021-01-26-mlp.md
+++ b/tutorials/_posts/2021-01-26-mlp.md
@@ -169,7 +169,7 @@ end
 * **Trains the model:** Defines the *callback* function `evalcb` to show the value of the `loss_all` function during the training process. Then, it sets [ADAM](https://fluxml.ai/Flux.jl/stable/training/optimisers/#Flux.Optimise.ADAM) as the optimiser for training out model. Finally, it runs the training process with the macro `@epochs` for `10` epochs (as defined in the `args` object) and shows the `accuracy` value for the train and test data.
 
 
-To see the full version of this example, see [Simple multi-layer perceptron - model-zoo](https://github.com/FluxML/model-zoo/blob/master/vision/mnist/mlp.jl).
+To see the full version of this example, see [Simple multi-layer perceptron - model-zoo](https://github.com/FluxML/model-zoo/blob/master/vision/mlp_mnist/mlp_mnist.jl).
  
 ## Resources
  


### PR DESCRIPTION
While i was going through the tutorial `Simple multi-layer perceptron`, i found that there is a broken link for accessing full version of this code example.
So i replaced the link with correct one 😀