### PR TITLE
Add governance page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -80,11 +80,14 @@
           <li class="nav-item">
             <a class="nav-link" href="https://fluxml.ai/Flux.jl/dev/ecosystem/">Ecosystem</a>
           </li>
-          <li class="nav-item">
+          <!-- <li class="nav-item">
             <a class="nav-link" href="/gsoc.html">GSoC</a>
           </li>
            <li class="nav-item">
             <a class="nav-link" href="/gsod.html">GSoD</a>
+          </li> -->
+          <li class="nav-item">
+            <a class="nav-link" href="/governance.html">Governance</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="https://discourse.julialang.org/c/domain/ML" target="_blank">Discuss</a>

--- a/governance.md
+++ b/governance.md
@@ -21,7 +21,9 @@ reflects the values of our community. Violations of the code should be
 reported to members of the steering council, where the offenses will be
 handled on a case-by-case basis.
 
-## Current Steering Council
+## Current Leadership
+
+### Current Steering Council
 
 - [Michael Abbott](https://github.com/mcabbott)
 - [Brian Chen](https://github.com/ToucheSir)
@@ -29,15 +31,15 @@ handled on a case-by-case basis.
 - [Carlo Lucibello](https://github.com/CarloLucibello)
 - [Lorenz Ohly](https://github.com/lorenzoh)
 
+### Advisory Committee
+
+To be decided.
+
 ### Former Steering Council
 
 - [Mike Innes](https://github.com/MikeInnes) (2016-2020)
 - [Dhairya Gandhi](https://github.com/DhairyaLGandhi) (2018-2020)
 - [Elliot Saba](https://github.com/staticfloat) (2018-2020)
-
-## Advisory Committee
-
-To be decided.
 
 # Governing Rules and Duties
 

--- a/governance.md
+++ b/governance.md
@@ -1,0 +1,160 @@
+---
+layout: page
+title: Governance
+---
+
+# FluxML Governance
+
+The following contains the formal governance structure of the FluxML
+project. This document clarifies how decisions are made with respect
+to community interactions, including the relationship between
+open source development and work that may be funded by for-profit
+and non-profit entities.
+
+## Code of Conduct
+
+The FluxML community strongly values inclusivity and diversity. Everyone
+should treat others with the utmost respect. Everyone in the community
+must adhere to the
+[NumFOCUS Code of Conduct](https://numfocus.org/code-of-conduct) which
+reflects the values of our community. Violations of the code should be
+reported to members of the steering council, where the offenses will be
+handled on a case-by-case basis.
+
+## Current Steering Council
+
+- [Michael Abbott](https://github.com/mcabbott)
+- [Brian Chen](https://github.com/ToucheSir)
+- [Kyle Daruwalla](https://github.com/darsnack)
+- [Carlo Lucibello](https://github.com/CarloLucibello)
+- [Lorenz Ohly](https://github.com/lorenzoh)
+
+### Former Steering Council
+
+- [Mike Innes](https://github.com/MikeInnes) (2016-2020)
+- [Dhairya Gandhi](https://github.com/DhairyaLGandhi) (2018-2020)
+- [Elliot Saba](https://github.com/staticfloat) (2018-2020)
+
+## Advisory Committee
+
+To be decided.
+
+# Governing Rules and Duties
+
+## Steering Council
+
+The Project has a Steering Council that consists of Project
+Contributors who have produced contributions that are substantial in
+quality and quantity, and sustained over at least one year. The role
+of the Council is to provide active leadership for the Project in
+making everyday decisions on technical and administrative issues,
+through working with and taking input from the Community.
+
+During the everyday project activities, Council Members participate in
+all discussions, code review and other project activities as peers
+with all other Contributors and the Community. In these everyday
+activities, Council Members do not have any special power or privilege
+through their membership on the Council. However, it is expected that
+because of the quality and quantity of their contributions and their
+expert knowledge of the Project Software and Services that Council
+Members will provide useful guidance, both technical and in terms of
+project direction, to potentially less experienced Contributors.
+
+The Steering Council and its Members play a special role in certain
+situations. In particular, the Council may:
+
+- Make decisions about the overall scope, vision and direction of
+  the project.
+- Make decisions about strategic collaborations with other
+  organizations or individuals.
+- Make decisions about specific technical issues, features, bugs and
+  pull requests. They are the primary mechanism of guiding the code
+  review process and merging pull requests.
+- Make decisions about the Services that are run by the Project and
+  manage those Services for the benefit of the Project and Community.
+- Make decisions when regular community discussion does not produce
+  consensus on an issue in a reasonable time frame.
+
+Steering Council decisions are taken by simple majority, with the
+exception of changes to the Governance Documents which follow the
+procedure in the section 'Changing the Governance Documents'.
+
+### Steering Council membership
+
+To become eligible for being a Steering Council Member, an individual
+must be a Project Contributor who has produced contributions that are
+substantial in quality and quantity, and sustained over at least one
+year. Potential Council Members are nominated by existing Council
+Members or by the Community and voted upon by the existing Council
+after asking if the potential Member is interested and willing to
+serve in that capacity.
+
+When considering potential Members, the Council will look at
+candidates with a comprehensive view of their contributions. This will
+include but is not limited to code, code review, infrastructure work,
+mailing list and chat participation, community help/building,
+education and outreach, design work, etc. We deliberately do not
+set arbitrary quantitative metrics to avoid encouraging behavior
+that plays to the metrics rather than the project's overall well-being.
+We want to encourage a diverse array of backgrounds, viewpoints and
+talents in our team, which is why we explicitly do not define code as
+the sole metric on which Council membership will be evaluated.
+
+If a Council Member becomes inactive in the project for a period of
+one year, they will be considered for removal from the Council. Before
+removal, the inactive Member will be approached by another Council
+member to ask if they plan on returning to active participation. If
+not they will be removed immediately upon a Council vote. If they plan
+on returning to active participation soon, they will be given a grace
+period of one year. If they do not return to active participation
+within that time period they will be removed by vote of the Council
+without further grace period. All former Council members can be
+considered for membership again at any time in the future, like any
+other Project Contributor. Retired Council members will be listed on
+the project website, acknowledging the period during which they were
+active in the Council.
+
+The Council reserves the right to eject current Members if they are
+deemed to be actively harmful to the Project's well-being, and
+attempts at communication and conflict resolution have failed.
+
+## Fiscal Decisions
+
+All fiscal decisions are made by the steering council to ensure any
+funds are spent in a manner that furthers the mission of the Project.
+Fiscal decisions require majority approval by acting steering council
+members.
+
+## Advisory Committee
+
+The Project has an Advisory Committee that works to ensure the long-term
+well-being of the Project. The Committee advises the Steering Council and
+may be called upon to break deadlocks or serious disagreements in the
+Council. The Community can ask the Committee to review actions taken by
+the Council, and the Committee will meet annually to review Project
+activities. Committee decisions are taken in consensus. Members of the
+Advisory Committee are appointed by the Steering Council.
+
+## Conflict of interest
+
+It is expected that Steering Council and Advisory Committee Members
+will be employed at a wide range of companies, universities and non-profit
+organizations. Because of this, it is possible that Members will have
+conflicts of interest. Such conflicts of interest include, but are not
+limited to:
+
+- Financial interests, such as investments, employment or contracting
+  work, outside of the Project that may influence their work on the
+  Project.
+- Access to proprietary information of their employer that could
+  potentially leak into their work with the Project.
+
+All members of the Council and Committee shall disclose any conflict of
+interest they may have. Members with a conflict of interest in a
+particular issue may participate in Council discussions on that issue,
+but must recuse themselves from voting on the issue.
+When a member fails to disclose a conflict of interest, any Contributor
+can raise this concern to the Council. The Council will discuss the issue
+and vote on whether the accused member should be removed. The member will
+have the opportunity to speak for their actions, but they will not participate
+in Council discussion or voting.

--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@ title: Elegant ML
       <div class="col-md feature">
         <h5>Metalhead</h5>
         <p>
-          <a href="https://github.com/FluxML/Metalhead.jl">Metalhead</a> includes many state-of-the-art computer vision models which can easily be used for transfer learning.
+          <a href="https://github.com/FluxML/Metalhead.jl">Metalhead.jl</a> includes many state-of-the-art computer vision models which can easily be used for transfer learning.
         </p>
       </div>
     </div>
@@ -236,7 +236,6 @@ title: Elegant ML
   </div>
 </div>
 
-
 <div class="features" style="background:white;padding-top:2em;">
   <div class="container">
     <div class="row">
@@ -246,14 +245,28 @@ title: Elegant ML
       </div>
     </div>
     <div class="row">
-
       <div class="col-md feature">
         <h5>Community team</h5>
         <p>
-          Join the <a href="https://github.com/FluxML/ML-Coordination-Tracker">group of community maintainers</a> supporting the FluxML ecosystem.
+          Join the <a href="https://github.com/FluxML/ML-Coordination-Tracker">group of community maintainers</a> supporting the FluxML ecosystem. Talk to us on Zulip! 👉
         </p>
       </div>
 
+      <div class="col-md feature">
+        <h5>Slack</h5>
+        <p>
+          <a href="https://julialang.org/slack/">Official Julia Slack</a> for casual conversation. See <code>#flux-bridged</code> and <code>#machine-learning</code>.
+        </p>
+      </div>
+ 
+      <div class="col-md feature">
+        <h5>Zulip</h5>
+        <p>
+          <a href="https://julialang.zulipchat.com">Zulip server</a> for the Julia programming language community. See <code>#ml-contributors</code> and <code>#machine-learning</code>.
+        </p>
+      </div>
+    </div>
+    <div class="row">
       <div class="col-md feature">
         <h5>Discourse forum</h5>
         <p>
@@ -261,26 +274,12 @@ title: Elegant ML
         </p>
       </div>
 
-
       <div class="col-md feature">
-        <h5>Slack</h5>
+        <h5>Stack Overflow</h5>
         <p>
-          <a href="https://julialang.org/slack/">Official Julia Slack</a> for casual conversation.
+          <a href="https://stackoverflow.com/questions/tagged/flux.jl">Ask questions</a> about Flux.jl.
         </p>
       </div>
- 
-      <div class="col-md feature">
-        <h5>Zulip</h5>
-        <p>
-          <a href="https://julialang.zulipchat.com">Zulip server</a> for the Julia programming language community.
-        </p>
-      </div>
-
-
-    </div>
-
-
-
     </div>
 
   </div>


### PR DESCRIPTION
As a NumFOCUS affiliated project, we need to have a governance model publicly listed on our website. I have adopted the [SciML model](https://sciml.ai/governance/) following suggestions on Slack. We already follow the SciML ColPrac guide for contributions, so it makes sense to follow their governance model as well.

I have listed the current and former steering council members based on who has contributed to the project over the last year. I have not filled out the advisory committee yet. Once we adopt this model and the initial council, the steering council can ask some community members to join the committee (I can think of a few people already who graciously lend their advice on difficult issues).